### PR TITLE
Add error check for HTTP response

### DIFF
--- a/digest_auth_client.go
+++ b/digest_auth_client.go
@@ -48,6 +48,10 @@ func (dr *DigestRequest) Execute() (resp *http.Response, err error) {
 		}
 		resp, err = client.Do(req)
 
+		if err != nil {
+			return nil, err
+		}
+
 		if resp.StatusCode == 401 {
 			return dr.executeNewDigest(resp)
 		}


### PR DESCRIPTION
A panic was occurred when a request cannot reach the target host. This patch is fix that.