### PR TITLE
Adding headers support & rename

### DIFF
--- a/authorization.go
+++ b/authorization.go
@@ -23,7 +23,7 @@ type authorization struct {
 	Qop       string // unquoted
 	Realm     string // quoted
 	Response  string // quoted
-	Uri       string // quoted
+	URI       string // quoted
 	Userhash  bool   // quoted
 	Username  string // quoted
 	Username_ string // quoted
@@ -40,7 +40,7 @@ func newAuthorization(dr *DigestRequest) (*authorization, error) {
 		Qop:       "",
 		Realm:     dr.Wa.Realm,
 		Response:  "",
-		Uri:       "",
+		URI:       "",
 		Userhash:  dr.Wa.Userhash,
 		Username:  "",
 		Username_: "", // TODO
@@ -61,12 +61,12 @@ func (ah *authorization) refreshAuthorization(dr *DigestRequest) (*authorization
 
 	ah.Cnonce = ah.hash(fmt.Sprintf("%d:%s:my_value", time.Now().UnixNano(), dr.Username))
 
-	url, err := url.Parse(dr.Uri)
+	url, err := url.Parse(dr.URI)
 	if err != nil {
 		return nil, err
 	}
 
-	ah.Uri = url.RequestURI()
+	ah.URI = url.RequestURI()
 	ah.Response = ah.computeResponse(dr)
 
 	return ah, nil
@@ -98,12 +98,12 @@ func (ah *authorization) computeA2(dr *DigestRequest) string {
 
 	if matched, _ := regexp.MatchString("auth-int", dr.Wa.Qop); matched {
 		ah.Qop = "auth-int"
-		return fmt.Sprintf("%s:%s:%s", dr.Method, ah.Uri, ah.hash(dr.Body))
+		return fmt.Sprintf("%s:%s:%s", dr.Method, ah.URI, ah.hash(dr.Body))
 	}
 
 	if dr.Wa.Qop == "auth" || dr.Wa.Qop == "" {
 		ah.Qop = "auth"
-		return fmt.Sprintf("%s:%s", dr.Method, ah.Uri)
+		return fmt.Sprintf("%s:%s", dr.Method, ah.URI)
 	}
 
 	return ""
@@ -162,8 +162,8 @@ func (ah *authorization) toString() string {
 		buffer.WriteString(fmt.Sprintf("response=\"%s\", ", ah.Response))
 	}
 
-	if ah.Uri != "" {
-		buffer.WriteString(fmt.Sprintf("uri=\"%s\", ", ah.Uri))
+	if ah.URI != "" {
+		buffer.WriteString(fmt.Sprintf("uri=\"%s\", ", ah.URI))
 	}
 
 	if ah.Userhash {

--- a/digest_auth_client.go
+++ b/digest_auth_client.go
@@ -11,8 +11,9 @@ type DigestRequest struct {
 	Body     string
 	Method   string
 	Password string
-	Uri      string
+	URI      string
 	Username string
+	Header   http.Header
 	Auth     *authorization
 	Wa       *wwwAuthenticate
 }
@@ -43,7 +44,7 @@ func (dr *DigestRequest) UpdateRequest(username, password, method, uri, body str
 	dr.Body = body
 	dr.Method = method
 	dr.Password = password
-	dr.Uri = uri
+	dr.URI = uri
 	dr.Username = username
 	return dr
 }
@@ -74,9 +75,10 @@ func (dr *DigestRequest) Execute() (resp *http.Response, err error) {
 	}
 
 	var req *http.Request
-	if req, err = http.NewRequest(dr.Method, dr.Uri, bytes.NewReader([]byte(dr.Body))); err != nil {
+	if req, err = http.NewRequest(dr.Method, dr.URI, bytes.NewReader([]byte(dr.Body))); err != nil {
 		return nil, err
 	}
+	req.Header = dr.Header
 
 	client := &http.Client{
 		Timeout: 30 * time.Second,
@@ -135,10 +137,10 @@ func (dr *DigestRequest) executeExistingDigest() (resp *http.Response, err error
 func (dr *DigestRequest) executeRequest(authString string) (resp *http.Response, err error) {
 	var req *http.Request
 
-	if req, err = http.NewRequest(dr.Method, dr.Uri, bytes.NewReader([]byte(dr.Body))); err != nil {
+	if req, err = http.NewRequest(dr.Method, dr.URI, bytes.NewReader([]byte(dr.Body))); err != nil {
 		return nil, err
 	}
-
+	req.Header = dr.Header
 	req.Header.Add("Authorization", authString)
 
 	client := &http.Client{

--- a/digest_auth_client.go
+++ b/digest_auth_client.go
@@ -46,6 +46,7 @@ func (dr *DigestRequest) UpdateRequest(username, password, method, uri, body str
 	dr.Password = password
 	dr.URI = uri
 	dr.Username = username
+	dr.Header = make(map[string][]string)
 	return dr
 }
 


### PR DESCRIPTION
I added the ability to add custom headers to the request by re-using the http.Headers type and renamed the .Uri to .URI in keeping with Go naming conventions.