### PR TITLE
Remove timeout on connection after auth completes

### DIFF
--- a/digest_auth_client.go
+++ b/digest_auth_client.go
@@ -141,9 +141,7 @@ func (dr *DigestRequest) executeRequest(authString string) (resp *http.Response,
 
 	req.Header.Add("Authorization", authString)
 
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
+	client := &http.Client{}
 
 	return client.Do(req)
 }


### PR DESCRIPTION
Don't enforce a timeout on the one using the lib after authentication completes