### PR TITLE
Missing quotes in Algorithm header regex

### DIFF
--- a/www_authenticate.go
+++ b/www_authenticate.go
@@ -21,7 +21,7 @@ func newWwwAuthenticate(s string) *wwwAuthenticate {
 
 	var wa = wwwAuthenticate{}
 
-	algorithmRegex := regexp.MustCompile(`algorithm=([^ ,]+)`)
+	algorithmRegex := regexp.MustCompile(`algorithm="([^ ,]+)"`)
 	algorithmMatch := algorithmRegex.FindStringSubmatch(s)
 	if algorithmMatch != nil {
 		wa.Algorithm = algorithmMatch[1]


### PR DESCRIPTION
The regular expression for parsing the Algorithm header is wrong: double quotes around the value are missing.