### PR TITLE
enable passing in a http client, for customizing TLS config and timeouts

### DIFF
--- a/digest_auth_client.go
+++ b/digest_auth_client.go
@@ -9,15 +9,16 @@ import (
 )
 
 type DigestRequest struct {
-	Body     string
-	Method   string
-	Password string
-	URI      string
-	Username string
-	Header   http.Header
-	Auth     *authorization
-	Wa       *wwwAuthenticate
-	CertVal  bool
+	Body       string
+	Method     string
+	Password   string
+	URI        string
+	Username   string
+	Header     http.Header
+	Auth       *authorization
+	Wa         *wwwAuthenticate
+	CertVal    bool
+	HTTPClient *http.Client
 }
 
 type DigestTransport struct {
@@ -39,6 +40,23 @@ func NewTransport(username, password string) DigestTransport {
 	dt.Password = password
 	dt.Username = username
 	return dt
+}
+
+func (dr *DigestRequest) getHTTPClient() *http.Client {
+	if dr.HTTPClient != nil {
+		return dr.HTTPClient
+	}
+	tlsConfig := tls.Config{}
+	if !dr.CertVal {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tlsConfig,
+		},
+	}
 }
 
 // UpdateRequest is called when you want to reuse an existing
@@ -84,16 +102,7 @@ func (dr *DigestRequest) Execute() (resp *http.Response, err error) {
 	}
 	req.Header = dr.Header
 
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
-
-	if !dr.CertVal {
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		client.Transport = tr
-	}
+	client := dr.getHTTPClient()
 
 	if resp, err = client.Do(req); err != nil {
 		return nil, err
@@ -155,16 +164,6 @@ func (dr *DigestRequest) executeRequest(authString string) (resp *http.Response,
 	req.Header = dr.Header
 	req.Header.Add("Authorization", authString)
 
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
-
-	if !dr.CertVal {
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		client.Transport = tr
-	}
-
+	client := dr.getHTTPClient()
 	return client.Do(req)
 }


### PR DESCRIPTION
i'm using this to allow setting custom timeouts and tls config like so:

```go
dr := dac.NewRequest(...)
verifyCert := func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
    // 
    return nil
}
dr.HTTPClient = &http.Client{
    Timeout: 15 * time.Second,
    Transport: &http.Transport{
        TLSClientConfig: &tls.Config{
            InsecureSkipVerify: true,
            VerifyPeerCertificate: verifyCert,
        },
    },
}
res, err = dr.Execute()
```

I've kept it backwards compatible with the existing CertVal functionality