### PR TITLE
custom HTTPClient for DigestTransport

### DIFF
--- a/digest_auth_client.go
+++ b/digest_auth_client.go
@@ -22,9 +22,9 @@ type DigestRequest struct {
 }
 
 type DigestTransport struct {
-	Password string
-	Username string
-	Timeout  time.Duration
+	Password   string
+	Username   string
+	HTTPClient *http.Client
 }
 
 // NewRequest creates a new DigestRequest object
@@ -40,7 +40,6 @@ func NewTransport(username, password string) DigestTransport {
 	dt := DigestTransport{}
 	dt.Password = password
 	dt.Username = username
-	dt.Timeout = 30 * time.Second
 	return dt
 }
 
@@ -88,6 +87,10 @@ func (dt *DigestTransport) RoundTrip(req *http.Request) (resp *http.Response, er
 	}
 
 	dr := NewRequest(username, password, method, uri, body)
+	if dt.HTTPClient != nil {
+		dr.HTTPClient = dt.HTTPClient
+	}
+
 	return dr.Execute()
 }
 


### PR DESCRIPTION
#13 broke custom timeout support for `DigestTransport`

This change allows using a custom `http.Client` for `DigestTransport`, which gets passed to any requests it makes.