### PR TITLE
copy headers from request for RoundTrip() method

### DIFF
--- a/digest_auth_client.go
+++ b/digest_auth_client.go
@@ -87,6 +87,7 @@ func (dt *DigestTransport) RoundTrip(req *http.Request) (resp *http.Response, er
 	}
 
 	dr := NewRequest(username, password, method, uri, body)
+	copyHeaders(req.Header, dr.Header)
 	if dt.HTTPClient != nil {
 		dr.HTTPClient = dt.HTTPClient
 	}
@@ -171,4 +172,12 @@ func (dr *DigestRequest) executeRequest(authString string) (resp *http.Response,
 
 	client := dr.getHTTPClient()
 	return client.Do(req)
+}
+
+func copyHeaders(src http.Header, dest http.Header) {
+	for key, values := range src {
+		for _, value := range values {
+			dest.Add(key, value)
+		}
+	}
 }


### PR DESCRIPTION
Hello,

headers are not copied from the Request to the DigestRequest in the RoundTrip() method. 
I had an impact during a POST method with a json body. I got a 415 error because the header "Content-Type" was not set properly.
So I've fixed it and I propose you this PR inspired from the issue #8 